### PR TITLE
身份驗證切面

### DIFF
--- a/src/main/java/me/ian/workoutrecoder/annotation/RequireAuth.java
+++ b/src/main/java/me/ian/workoutrecoder/annotation/RequireAuth.java
@@ -1,0 +1,11 @@
+package me.ian.workoutrecoder.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequireAuth {
+}

--- a/src/main/java/me/ian/workoutrecoder/aop/AuthAspect.java
+++ b/src/main/java/me/ian/workoutrecoder/aop/AuthAspect.java
@@ -1,0 +1,46 @@
+package me.ian.workoutrecoder.aop;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import me.ian.workoutrecoder.annotation.RequireAuth;
+import me.ian.workoutrecoder.exception.AuthenticationException;
+import me.ian.workoutrecoder.model.po.UserPO;
+import me.ian.workoutrecoder.repository.UserRepository;
+import me.ian.workoutrecoder.service.JwtService;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Aspect
+@Component
+public class AuthAspect {
+    private final JwtService jwtService;
+    private final UserRepository userRepository;
+    private static final String TOKEN_PREFIX = "Bearer ";
+
+    public AuthAspect(JwtService jwtService, UserRepository userRepository) {
+        this.jwtService = jwtService;
+        this.userRepository = userRepository;
+    }
+
+
+    @Around("@within(requireAuth) || @annotation(requireAuth)")
+    public Object authenticateToken(ProceedingJoinPoint joinPoint, RequireAuth requireAuth) throws Throwable {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
+        String token = request.getHeader("Authorization").replace(TOKEN_PREFIX, "");
+        Integer userId = request.getIntHeader("X-User-Id");
+
+        Claims claims = jwtService.parseToken(token);
+        String account = claims.getSubject();
+
+        UserPO user = userRepository.findByAccount(account);
+        if (user == null || !user.getId().equals(userId)) {
+            throw new AuthenticationException();
+        }
+
+        return joinPoint.proceed();
+    }
+}

--- a/src/main/java/me/ian/workoutrecoder/enums/ApplicationResponseCodeEnum.java
+++ b/src/main/java/me/ian/workoutrecoder/enums/ApplicationResponseCodeEnum.java
@@ -11,6 +11,7 @@ public enum ApplicationResponseCodeEnum {
     ACTION_ALREADY_EXIST(10004, "Action is already exist"),
     USER_NOT_EXIST(10005, "User is not exist, please register"),
     PASSWORD_WRONG(10006, "Password is wrong"),
+    AUTHENTICATE_FAILED(10007, "Authentication illegal"),
     DATA_NOT_EXIST(11000, "Data not exist")
     ;
 

--- a/src/main/java/me/ian/workoutrecoder/exception/AuthenticationException.java
+++ b/src/main/java/me/ian/workoutrecoder/exception/AuthenticationException.java
@@ -1,0 +1,4 @@
+package me.ian.workoutrecoder.exception;
+
+public class AuthenticationException extends RuntimeException {
+}

--- a/src/main/java/me/ian/workoutrecoder/exception/GlobalExceptionHandler.java
+++ b/src/main/java/me/ian/workoutrecoder/exception/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package me.ian.workoutrecoder.exception;
 
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.security.SignatureException;
 import jakarta.validation.ConstraintViolationException;
 import me.ian.workoutrecoder.controller.common.RestResponse;
 import me.ian.workoutrecoder.enums.ApplicationResponseCodeEnum;
@@ -10,6 +12,8 @@ import org.springframework.web.bind.*;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import javax.security.sasl.AuthenticationException;
 
 
 @RestControllerAdvice
@@ -36,5 +40,15 @@ public class GlobalExceptionHandler {
     @ExceptionHandler({RestException.class})
     public RestResponse handleRestException(RestException e) {
         return new RestResponse(e.getCode(), e.getMsg());
+    }
+
+    @ExceptionHandler({
+            ExpiredJwtException.class,
+            SignatureException.class,
+            AuthenticationException.class
+    })
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public RestResponse handleAuthorizationException(Exception e) {
+        return new RestResponse(ApplicationResponseCodeEnum.AUTHENTICATE_FAILED.getCode(), e.getMessage());
     }
 }

--- a/src/main/java/me/ian/workoutrecoder/service/JwtService.java
+++ b/src/main/java/me/ian/workoutrecoder/service/JwtService.java
@@ -1,9 +1,13 @@
 package me.ian.workoutrecoder.service;
 
+import io.jsonwebtoken.Claims;
+
 public interface JwtService {
     String createAuthenticationToken(String subject);
 
     String createRefreshToken(String subject);
 
     long getExpiration();
+
+    Claims parseToken(String jwt);
 }

--- a/src/main/java/me/ian/workoutrecoder/service/impl/JwtServiceImpl.java
+++ b/src/main/java/me/ian/workoutrecoder/service/impl/JwtServiceImpl.java
@@ -1,5 +1,6 @@
 package me.ian.workoutrecoder.service.impl;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import me.ian.workoutrecoder.service.JwtService;
@@ -63,5 +64,14 @@ public class JwtServiceImpl implements JwtService {
     @Override
     public long getExpiration() {
         return this.AUTHENTICATION_VALID_SECONDS;
+    }
+
+    @Override
+    public Claims parseToken(String jwt) {
+        return Jwts.parserBuilder()
+                .setSigningKey(this.getSigningKey())
+                .build()
+                .parseClaimsJws(jwt)
+                .getBody();
     }
 }

--- a/src/test/java/me/ian/workoutrecoder/aop/AuthAspectTest.java
+++ b/src/test/java/me/ian/workoutrecoder/aop/AuthAspectTest.java
@@ -1,0 +1,99 @@
+package me.ian.workoutrecoder.aop;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import me.ian.workoutrecoder.annotation.RequireAuth;
+import me.ian.workoutrecoder.exception.AuthenticationException;
+import me.ian.workoutrecoder.model.po.UserPO;
+import me.ian.workoutrecoder.repository.UserRepository;
+import me.ian.workoutrecoder.service.JwtService;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthAspectTest {
+    @Mock
+    UserRepository userRepository;
+    @Mock
+    ProceedingJoinPoint joinPoint;
+    @Mock
+    RequireAuth requireAuth;
+    @Mock
+    JwtService jwtService;
+    @Mock
+    private Claims claims;
+
+    MockHttpServletRequest request;
+
+    AuthAspect authAspect;
+
+    @BeforeEach
+    public void setup() {
+        request = new MockHttpServletRequest();
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        authAspect = new AuthAspect(jwtService, userRepository);
+    }
+
+    @Test
+    public void givenExpiredToken_whenAuthenticateToken_thenThrowExpiredJwtException() {
+        String token = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI5M2VkNjUzZS05ZDY1LTQ1NzAtYTc5ZS0yNTY1NDAyZjM1OTkiLCJzdWIiOiJhY2NvdW50IiwiaWF0IjoxNzIwMjY4ODU5LCJleHAiOjE3MjAyNjg5MTl9.87Tr4PECyWFsfQbgt_EXwHteEGBJQJ3427BaqTftWjk";
+        String jwt = "eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI5M2VkNjUzZS05ZDY1LTQ1NzAtYTc5ZS0yNTY1NDAyZjM1OTkiLCJzdWIiOiJhY2NvdW50IiwiaWF0IjoxNzIwMjY4ODU5LCJleHAiOjE3MjAyNjg5MTl9.87Tr4PECyWFsfQbgt_EXwHteEGBJQJ3427BaqTftWjk";
+
+        request.addHeader("Authorization", token);
+        request.addHeader("X-User-Id", String.valueOf(1));
+
+        when(jwtService.parseToken(jwt)).thenThrow(ExpiredJwtException.class);
+
+        assertThrows(ExpiredJwtException.class, () -> authAspect.authenticateToken(joinPoint, requireAuth));
+    }
+
+    @Test
+    public void givenWrongSubjectToken_whenAuthenticateToken_thenThrowAuthenticationException() {
+        String token = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI5M2VkNjUzZS05ZDY1LTQ1NzAtYTc5ZS0yNTY1NDAyZjM1OTkiLCJzdWIiOiJhY2NvdW50IiwiaWF0IjoxNzIwMjY4ODU5LCJleHAiOjE3MjAyNjg5MTl9.87Tr4PECyWFsfQbgt_EXwHteEGBJQJ3427BaqTftWjk";
+        String jwt = "eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI5M2VkNjUzZS05ZDY1LTQ1NzAtYTc5ZS0yNTY1NDAyZjM1OTkiLCJzdWIiOiJhY2NvdW50IiwiaWF0IjoxNzIwMjY4ODU5LCJleHAiOjE3MjAyNjg5MTl9.87Tr4PECyWFsfQbgt_EXwHteEGBJQJ3427BaqTftWjk";
+
+        request.addHeader("Authorization", token);
+        request.addHeader("X-User-Id", String.valueOf(1));
+
+        when(jwtService.parseToken(jwt)).thenReturn(claims);
+        when(claims.getSubject()).thenReturn("test");
+
+        UserPO userPO = new UserPO();
+        userPO.setId(2);
+        when(userRepository.findByAccount("test")).thenReturn(userPO);
+
+        assertThrows(AuthenticationException.class, () -> authAspect.authenticateToken(joinPoint, requireAuth));
+    }
+
+    @Test
+    public void givenCorrectToken_whenAuthenticateToken_thenJoinPointDoProceed() throws Throwable {
+        String token = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI5M2VkNjUzZS05ZDY1LTQ1NzAtYTc5ZS0yNTY1NDAyZjM1OTkiLCJzdWIiOiJhY2NvdW50IiwiaWF0IjoxNzIwMjY4ODU5LCJleHAiOjE3MjAyNjg5MTl9.87Tr4PECyWFsfQbgt_EXwHteEGBJQJ3427BaqTftWjk";
+        String jwt = "eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI5M2VkNjUzZS05ZDY1LTQ1NzAtYTc5ZS0yNTY1NDAyZjM1OTkiLCJzdWIiOiJhY2NvdW50IiwiaWF0IjoxNzIwMjY4ODU5LCJleHAiOjE3MjAyNjg5MTl9.87Tr4PECyWFsfQbgt_EXwHteEGBJQJ3427BaqTftWjk";
+
+        request.addHeader("Authorization", token);
+        request.addHeader("X-User-Id", String.valueOf(1));
+
+        when(jwtService.parseToken(jwt)).thenReturn(claims);
+        when(claims.getSubject()).thenReturn("test");
+
+        UserPO userPO = new UserPO();
+        userPO.setId(1);
+        when(userRepository.findByAccount("test")).thenReturn(userPO);
+
+        when(joinPoint.proceed()).thenReturn("Success");
+
+        Object result = authAspect.authenticateToken(joinPoint, requireAuth);
+        assertEquals("Success", result);
+    }
+}

--- a/src/test/java/me/ian/workoutrecoder/service/impl/JwtServiceImplTest.java
+++ b/src/test/java/me/ian/workoutrecoder/service/impl/JwtServiceImplTest.java
@@ -12,7 +12,7 @@ class JwtServiceImplTest {
 
     @BeforeEach
     public void setup() {
-        jwtService = new JwtServiceImpl("IKvcenK3ZwOunElJ3m1hUyLZIzhaJSql", 30, 43200);
+        jwtService = new JwtServiceImpl("testtesttesttesttesttesttesttest", 1, 43200);
     }
 
     @Test


### PR DESCRIPTION
# Modification
* `JwtService` 實作解析 jwt
* 新增 RequireAuth 註解
* 實作身份驗證切面

# Local Test
## case1: 攜帶過期的 jwt
### Expect
Response code: 401  
Application code: 10007  
Error msg: token expired

### Execute
```sh
curl --location 'http://localhost:8080/workout/action' \
--header 'X-User-Id: 1' \
--header 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJjNGUzYTNhNC1mYTdhLTQ4NTMtYjVjYS0wOTIzYzBiNGNmMzUiLCJzdWIiOiJhYmNkMDAwMSIsImlhdCI6MTcyMDI1NTE4MSwiZXhwIjoxNzIwMjU2OTgxfQ.EvPJGyzj4bzusBo3lsv4UBbo05Cb0uBJjJZrQYzwxIY'
```
Response
<img width="219" alt="image" src="https://github.com/Jumple86/workout-logger/assets/88960591/11422eb2-9e52-43f0-9d37-8164759dfe58">

```json
{
    "code": 10007,
    "msg": "JWT expired at 2024-07-06T09:09:41Z. Current time: 2024-07-06T14:09:36Z, a difference of 17995990 milliseconds.  Allowed clock skew: 0 milliseconds.",
    "data": null
}
```

## case2: 攜帶合法的 jwt
### Expect
Response code: 200  
Application code: 1  
Error msg: null

### Execute
```sh
curl --location 'http://localhost:8080/workout/action' \
--header 'X-User-Id: 1' \
--header 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIzMDA4NWQyNi05ZGQ5LTRiOTEtODk1Yi03YmJkZDdiYjZkMGYiLCJzdWIiOiJhYmNkMDAwMSIsImlhdCI6MTcyMDI4MDI3NCwiZXhwIjoxNzIwMjgyMDc0fQ.6t9ZtVsBAu52TQUr4y0XQaDk-_VdI_tyJ1H519iD0vw'
```

Response
<img width="175" alt="image" src="https://github.com/Jumple86/workout-logger/assets/88960591/3eb3dd4e-e3fd-4439-bdc7-30a2a31d9c13">
```json
{
    "code": 1,
    "msg": null,
    "data": {
        "user_id": 1,
        "nickname": null,
        "workout_actions": [
            {
                "id": 1,
                "parts": "肩",
                "name": "啞鈴肩推",
                "create_at": "2024-07-03T01:42:34",
                "update_at": "2024-07-03T01:42:34"
            }
        ]
    }
}
```