### PR TITLE
feat: create workout menu

### DIFF
--- a/src/main/java/me/ian/workoutrecoder/controller/WorkoutMenuController.java
+++ b/src/main/java/me/ian/workoutrecoder/controller/WorkoutMenuController.java
@@ -1,0 +1,23 @@
+package me.ian.workoutrecoder.controller;
+
+import jakarta.validation.Valid;
+import me.ian.workoutrecoder.controller.common.RestResponse;
+import me.ian.workoutrecoder.model.param.CreateWorkoutMenuParam;
+import me.ian.workoutrecoder.service.WorkoutMenuService;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/workout/menu")
+public class WorkoutMenuController {
+    private final WorkoutMenuService workoutMenuService;
+
+    public WorkoutMenuController(WorkoutMenuService workoutMenuService) {
+        this.workoutMenuService = workoutMenuService;
+    }
+
+    @PostMapping
+    public RestResponse<Integer> createMenu(@RequestHeader(name = "X-User-Id") Integer userId,
+                                            @RequestBody @Valid CreateWorkoutMenuParam param) {
+        return new RestResponse<>(workoutMenuService.createWorkoutMenu(userId, param));
+    }
+}

--- a/src/main/java/me/ian/workoutrecoder/enums/ApplicationResponseCodeEnum.java
+++ b/src/main/java/me/ian/workoutrecoder/enums/ApplicationResponseCodeEnum.java
@@ -12,6 +12,8 @@ public enum ApplicationResponseCodeEnum {
     USER_NOT_EXIST(10005, "User is not exist, please register"),
     PASSWORD_WRONG(10006, "Password is wrong"),
     AUTHENTICATE_FAILED(10007, "Authentication illegal"),
+    ALREADY_CREATED_WEEKLY_MENU(10008, "Already created weekly menu"),
+    MENU_ALREADY_EXIST(10009, "Menu is already exist"),
     DATA_NOT_EXIST(11000, "Data not exist")
     ;
 

--- a/src/main/java/me/ian/workoutrecoder/enums/MenuTypeEnum.java
+++ b/src/main/java/me/ian/workoutrecoder/enums/MenuTypeEnum.java
@@ -1,0 +1,15 @@
+package me.ian.workoutrecoder.enums;
+
+public enum MenuTypeEnum {
+    CUSTOM(1),
+    WEEKLY(2);
+    private int code;
+
+    MenuTypeEnum(int code) {
+        this.code = code;
+    }
+
+    public int getCode() {
+        return this.code;
+    }
+}

--- a/src/main/java/me/ian/workoutrecoder/model/param/CreateWorkoutMenuParam.java
+++ b/src/main/java/me/ian/workoutrecoder/model/param/CreateWorkoutMenuParam.java
@@ -1,0 +1,17 @@
+package me.ian.workoutrecoder.model.param;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateWorkoutMenuParam {
+    @NotEmpty
+    private String name;
+    @NotNull
+    private Integer type;
+}

--- a/src/main/java/me/ian/workoutrecoder/model/po/WorkoutMenuPO.java
+++ b/src/main/java/me/ian/workoutrecoder/model/po/WorkoutMenuPO.java
@@ -1,0 +1,27 @@
+package me.ian.workoutrecoder.model.po;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.sql.Timestamp;
+
+@Data
+@Entity
+@Table(name = "workout_menu")
+public class WorkoutMenuPO {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Integer id;
+    @ManyToOne(cascade = CascadeType.REFRESH, fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private UserPO userId;
+    @Column(name = "name")
+    private String name;
+    @Column(name = "type")
+    private Integer type;
+    @Column(name = "create_at", insertable = false, updatable = false)
+    private Timestamp createAt;
+    @Column(name = "update_at", insertable = false, updatable = false)
+    private Timestamp updateAt;
+}

--- a/src/main/java/me/ian/workoutrecoder/repository/WorkoutMenuRepository.java
+++ b/src/main/java/me/ian/workoutrecoder/repository/WorkoutMenuRepository.java
@@ -1,0 +1,33 @@
+package me.ian.workoutrecoder.repository;
+
+import me.ian.workoutrecoder.model.po.WorkoutMenuPO;
+import me.ian.workoutrecoder.repository.specs.WorkoutMenuSpecs;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface WorkoutMenuRepository extends CrudRepository<WorkoutMenuPO, Integer>, JpaSpecificationExecutor<WorkoutMenuPO> {
+
+
+    default List<WorkoutMenuPO> findBySpecification(Integer userId, String name, Integer type) {
+        Specification specification = Specification.where(null);
+
+        if (userId != null) {
+            specification = specification.and(WorkoutMenuSpecs.userIdEquals(userId));
+        }
+
+        if (name != null) {
+            specification = specification.and(WorkoutMenuSpecs.nameEquals(name));
+        }
+
+        if (type != null) {
+            specification = specification.and(WorkoutMenuSpecs.typeEquals(type));
+        }
+
+        return findAll(specification);
+    }
+}

--- a/src/main/java/me/ian/workoutrecoder/repository/specs/WorkoutMenuSpecs.java
+++ b/src/main/java/me/ian/workoutrecoder/repository/specs/WorkoutMenuSpecs.java
@@ -1,0 +1,18 @@
+package me.ian.workoutrecoder.repository.specs;
+
+import org.springframework.data.jpa.domain.Specification;
+
+public class WorkoutMenuSpecs {
+
+    public static Specification userIdEquals(Integer userId) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("userId").get("id"), userId);
+    }
+
+    public static Specification nameEquals(String name) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("name"), name);
+    }
+
+    public static Specification typeEquals(Integer type) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("type"), type);
+    }
+}

--- a/src/main/java/me/ian/workoutrecoder/service/CreateWorkoutMenuService.java
+++ b/src/main/java/me/ian/workoutrecoder/service/CreateWorkoutMenuService.java
@@ -1,0 +1,10 @@
+package me.ian.workoutrecoder.service;
+
+import me.ian.workoutrecoder.model.param.CreateWorkoutMenuParam;
+
+public interface CreateWorkoutMenuService {
+
+    int createCustomMenu(Integer userId, CreateWorkoutMenuParam param);
+
+    int createWeeklyMenu(Integer userId, CreateWorkoutMenuParam param);
+}

--- a/src/main/java/me/ian/workoutrecoder/service/WorkoutMenuService.java
+++ b/src/main/java/me/ian/workoutrecoder/service/WorkoutMenuService.java
@@ -1,0 +1,7 @@
+package me.ian.workoutrecoder.service;
+
+import me.ian.workoutrecoder.model.param.CreateWorkoutMenuParam;
+
+public interface WorkoutMenuService {
+    Integer createWorkoutMenu(Integer userId, CreateWorkoutMenuParam param);
+}

--- a/src/main/java/me/ian/workoutrecoder/service/impl/CreateWorkoutMenuServiceImpl.java
+++ b/src/main/java/me/ian/workoutrecoder/service/impl/CreateWorkoutMenuServiceImpl.java
@@ -1,0 +1,63 @@
+package me.ian.workoutrecoder.service.impl;
+
+import me.ian.workoutrecoder.enums.ApplicationResponseCodeEnum;
+import me.ian.workoutrecoder.enums.MenuTypeEnum;
+import me.ian.workoutrecoder.exception.RestException;
+import me.ian.workoutrecoder.model.param.CreateWorkoutMenuParam;
+import me.ian.workoutrecoder.model.po.UserPO;
+import me.ian.workoutrecoder.model.po.WorkoutMenuPO;
+import me.ian.workoutrecoder.repository.WorkoutMenuRepository;
+import me.ian.workoutrecoder.service.CreateWorkoutMenuService;
+import me.ian.workoutrecoder.util.BeanConvertUtils;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CreateWorkoutMenuServiceImpl implements CreateWorkoutMenuService {
+    private final WorkoutMenuRepository workoutMenuRepository;
+
+    public CreateWorkoutMenuServiceImpl(WorkoutMenuRepository workoutMenuRepository) {
+        this.workoutMenuRepository = workoutMenuRepository;
+    }
+
+    @Override
+    public int createCustomMenu(Integer userId, CreateWorkoutMenuParam param) {
+        WorkoutMenuPO workoutMenuPO = this.doSave(userId, param);
+
+        return workoutMenuPO.getId();
+    }
+
+    @Override
+    public int createWeeklyMenu(Integer userId, CreateWorkoutMenuParam param) {
+        List<WorkoutMenuPO> workoutMenus = workoutMenuRepository.findBySpecification(userId, null, MenuTypeEnum.WEEKLY.getCode());
+        if (!workoutMenus.isEmpty()) {
+            throw new RestException(ApplicationResponseCodeEnum.ALREADY_CREATED_WEEKLY_MENU.getCode());
+        }
+
+        WorkoutMenuPO workoutMenuPO = this.doSave(userId, param);
+        return workoutMenuPO.getId();
+    }
+
+    private WorkoutMenuPO doSave(Integer userId, CreateWorkoutMenuParam param) {
+        WorkoutMenuPO workoutMenuPO = BeanConvertUtils.convert(param, WorkoutMenuPO.class);
+        UserPO userPO = this.buildUserPO(userId);
+        workoutMenuPO.setUserId(userPO);
+
+        try {
+            workoutMenuPO = workoutMenuRepository.save(workoutMenuPO);
+        } catch (DataIntegrityViolationException e) {
+            throw new RestException(ApplicationResponseCodeEnum.MENU_ALREADY_EXIST.getCode());
+        }
+
+        return workoutMenuPO;
+    }
+
+    private UserPO buildUserPO(Integer userId) {
+        UserPO userPO = new UserPO();
+        userPO.setId(userId);
+
+        return userPO;
+    }
+}

--- a/src/main/java/me/ian/workoutrecoder/service/impl/WorkoutMenuServiceImpl.java
+++ b/src/main/java/me/ian/workoutrecoder/service/impl/WorkoutMenuServiceImpl.java
@@ -1,0 +1,36 @@
+package me.ian.workoutrecoder.service.impl;
+
+import me.ian.workoutrecoder.enums.ApplicationResponseCodeEnum;
+import me.ian.workoutrecoder.enums.MenuTypeEnum;
+import me.ian.workoutrecoder.exception.RestException;
+import me.ian.workoutrecoder.model.param.CreateWorkoutMenuParam;
+import me.ian.workoutrecoder.model.po.UserPO;
+import me.ian.workoutrecoder.model.po.WorkoutMenuPO;
+import me.ian.workoutrecoder.repository.WorkoutMenuRepository;
+import me.ian.workoutrecoder.service.CreateWorkoutMenuService;
+import me.ian.workoutrecoder.service.WorkoutMenuService;
+import me.ian.workoutrecoder.util.BeanConvertUtils;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class WorkoutMenuServiceImpl implements WorkoutMenuService {
+    private final CreateWorkoutMenuService createWorkoutMenuService;
+
+    public WorkoutMenuServiceImpl(CreateWorkoutMenuService createWorkoutMenuService) {
+        this.createWorkoutMenuService = createWorkoutMenuService;
+    }
+
+    @Override
+    public Integer createWorkoutMenu(Integer userId, CreateWorkoutMenuParam param) {
+        if (MenuTypeEnum.CUSTOM.getCode() == param.getType()) {
+            return createWorkoutMenuService.createCustomMenu(userId, param);
+        }
+
+        if (MenuTypeEnum.WEEKLY.getCode() == param.getType()) {
+            return createWorkoutMenuService.createWeeklyMenu(userId, param);
+        }
+
+        throw new RestException(ApplicationResponseCodeEnum.PARAMETER_WRONG.getCode());
+    }
+}


### PR DESCRIPTION
# Modification
* 建立 WorkoutMenu 相關的 repository 跟 specification
* `ApplicationResponseEnum` 新增相關 enum
* 實作建立菜單相關邏輯

# Local Test
## case1: 正常建立菜單
**預期: 回傳菜單 id**  
```sh
curl --location 'http://localhost:8080/workout/menu' \
--header 'X-User-Id: 2' \
--header 'Content-Type: application/json' \
--data '{
	"name": "TEST_menu1",
	"type": 1
}'
```
Response
```json
{
    "code": 1,
    "msg": null,
    "data": 1
}
```

查看 DB, 結果符合預期
```sql
mysql> SELECT * FROM workout_logger.workout_menu WHERE id = 1;
+----+---------+------------+------+---------------------+---------------------+
| id | user_id | name       | type | create_at           | update_at           |
+----+---------+------------+------+---------------------+---------------------+
|  1 |       2 | TEST_menu1 |    1 | 2024-07-14 16:45:22 | 2024-07-14 16:45:22 |
+----+---------+------------+------+---------------------+---------------------+
1 row in set (0.00 sec)
```

## case2: 建立的菜單名稱重複
**預期: 回傳菜單已存在錯誤訊息**  
```sh
curl --location 'http://localhost:8080/workout/menu' \
--header 'X-User-Id: 2' \
--header 'Content-Type: application/json' \
--data '{
	"name": "TEST_menu1",
	"type": 1
}'
```
Response  
```json
{
    "code": 10009,
    "msg": "Menu is already exist",
    "data": null
}
```
結果如預期

## case3: 建立超過一個整週菜單
**預期: 回傳整週菜單已建立錯誤訊息**    

先正常建立一個整週菜單
```sh
curl --location 'http://localhost:8080/workout/menu' \
--header 'X-User-Id: 2' \
--header 'Content-Type: application/json' \
--data '{
	"name": "TEST_menu2",
	"type": 2
}'
```
Response
```json
{
    "code": 1,
    "msg": null,
    "data": 3
}
```

再建立一個整週菜單(名稱改為 TEST_menu3 避免菜單已存在錯誤訊息)
```sh
curl --location 'http://localhost:8080/workout/menu' \
--header 'X-User-Id: 2' \
--header 'Content-Type: application/json' \
--data '{
    "name": "TEST_menu3",
    "type": 2
}'
```
Response
```json
{
    "code": 10008,
    "msg": "Already created weekly menu",
    "data": null
}
```
回傳結果如預期