### PR TITLE
feat: get menu list

### DIFF
--- a/src/main/java/me/ian/workoutrecoder/controller/WorkoutMenuController.java
+++ b/src/main/java/me/ian/workoutrecoder/controller/WorkoutMenuController.java
@@ -3,8 +3,11 @@ package me.ian.workoutrecoder.controller;
 import jakarta.validation.Valid;
 import me.ian.workoutrecoder.controller.common.RestResponse;
 import me.ian.workoutrecoder.model.param.CreateWorkoutMenuParam;
+import me.ian.workoutrecoder.model.vo.GetWorkoutMenuListVO;
 import me.ian.workoutrecoder.service.WorkoutMenuService;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/workout/menu")
@@ -19,5 +22,11 @@ public class WorkoutMenuController {
     public RestResponse<Integer> createMenu(@RequestHeader(name = "X-User-Id") Integer userId,
                                             @RequestBody @Valid CreateWorkoutMenuParam param) {
         return new RestResponse<>(workoutMenuService.createWorkoutMenu(userId, param));
+    }
+
+    @GetMapping
+    public RestResponse<List<GetWorkoutMenuListVO>> getMenuList(@RequestHeader(name = "X-User-Id") Integer userId) {
+
+        return new RestResponse<>(workoutMenuService.getWorkoutMenuList(userId));
     }
 }

--- a/src/main/java/me/ian/workoutrecoder/exception/GlobalExceptionHandler.java
+++ b/src/main/java/me/ian/workoutrecoder/exception/GlobalExceptionHandler.java
@@ -32,9 +32,12 @@ public class GlobalExceptionHandler {
         return new RestResponse(ApplicationResponseCodeEnum.PARAMETER_WRONG.getCode(), bindingResult.getAllErrors().get(0).getDefaultMessage());
     }
 
-    @ExceptionHandler(MissingServletRequestParameterException.class)
+    @ExceptionHandler({
+            MissingServletRequestParameterException.class,
+            MissingRequestHeaderException.class
+    })
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public RestResponse handleMissingParameterException(MissingServletRequestParameterException e) {
+    public RestResponse handleMissingParameterException(Exception e) {
         return new RestResponse(ApplicationResponseCodeEnum.PARAMETER_WRONG.getCode(), e.getMessage());
     }
 

--- a/src/main/java/me/ian/workoutrecoder/model/vo/GetWorkoutMenuListVO.java
+++ b/src/main/java/me/ian/workoutrecoder/model/vo/GetWorkoutMenuListVO.java
@@ -1,0 +1,13 @@
+package me.ian.workoutrecoder.model.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetWorkoutMenuListVO {
+    private Integer id;
+    private String name;
+}

--- a/src/main/java/me/ian/workoutrecoder/service/WorkoutMenuService.java
+++ b/src/main/java/me/ian/workoutrecoder/service/WorkoutMenuService.java
@@ -1,7 +1,12 @@
 package me.ian.workoutrecoder.service;
 
 import me.ian.workoutrecoder.model.param.CreateWorkoutMenuParam;
+import me.ian.workoutrecoder.model.vo.GetWorkoutMenuListVO;
+
+import java.util.List;
 
 public interface WorkoutMenuService {
     Integer createWorkoutMenu(Integer userId, CreateWorkoutMenuParam param);
+
+    List<GetWorkoutMenuListVO> getWorkoutMenuList(Integer userId);
 }

--- a/src/main/java/me/ian/workoutrecoder/service/impl/WorkoutMenuServiceImpl.java
+++ b/src/main/java/me/ian/workoutrecoder/service/impl/WorkoutMenuServiceImpl.java
@@ -6,6 +6,7 @@ import me.ian.workoutrecoder.exception.RestException;
 import me.ian.workoutrecoder.model.param.CreateWorkoutMenuParam;
 import me.ian.workoutrecoder.model.po.UserPO;
 import me.ian.workoutrecoder.model.po.WorkoutMenuPO;
+import me.ian.workoutrecoder.model.vo.GetWorkoutMenuListVO;
 import me.ian.workoutrecoder.repository.WorkoutMenuRepository;
 import me.ian.workoutrecoder.service.CreateWorkoutMenuService;
 import me.ian.workoutrecoder.service.WorkoutMenuService;
@@ -13,12 +14,18 @@ import me.ian.workoutrecoder.util.BeanConvertUtils;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 @Service
 public class WorkoutMenuServiceImpl implements WorkoutMenuService {
     private final CreateWorkoutMenuService createWorkoutMenuService;
+    private final WorkoutMenuRepository workoutMenuRepository;
 
-    public WorkoutMenuServiceImpl(CreateWorkoutMenuService createWorkoutMenuService) {
+    public WorkoutMenuServiceImpl(CreateWorkoutMenuService createWorkoutMenuService, WorkoutMenuRepository workoutMenuRepository) {
         this.createWorkoutMenuService = createWorkoutMenuService;
+        this.workoutMenuRepository = workoutMenuRepository;
     }
 
     @Override
@@ -32,5 +39,16 @@ public class WorkoutMenuServiceImpl implements WorkoutMenuService {
         }
 
         throw new RestException(ApplicationResponseCodeEnum.PARAMETER_WRONG.getCode());
+    }
+
+    @Override
+    public List<GetWorkoutMenuListVO> getWorkoutMenuList(Integer userId) {
+        List<WorkoutMenuPO> workoutMenuPOs = workoutMenuRepository.findBySpecification(userId, null, null);
+
+        List<GetWorkoutMenuListVO> result = workoutMenuPOs.stream()
+                .map(po -> new GetWorkoutMenuListVO(po.getId(), po.getName()))
+                .collect(Collectors.toList());
+
+        return result;
     }
 }


### PR DESCRIPTION
# Modification
* 修改 `GlobalExceptionHandler`, 新增缺少 HttpHeader 時的錯誤處理
* 新增取得單一用戶所有菜單實作邏輯 (就單純 get by userId 而已)

# Local Test
查看資料庫資料
```sql
mysql> SELECT * FROM workout_logger.workout_menu;
+----+---------+------------+------+---------------------+---------------------+
| id | user_id | name       | type | create_at           | update_at           |
+----+---------+------------+------+---------------------+---------------------+
|  1 |       2 | TEST_menu1 |    1 | 2024-07-14 16:45:22 | 2024-07-14 16:45:22 |
|  3 |       2 | TEST_menu2 |    2 | 2024-07-14 16:49:41 | 2024-07-14 16:49:41 |
+----+---------+------------+------+---------------------+---------------------+
2 rows in set (0.00 sec)
```

呼叫 API
```sh
curl --location 'http://localhost:8080/workout/menu'
```
```json
{
    "code": 1,
    "msg": null,
    "data": [
        {
            "id": 1,
            "name": "TEST_menu1"
        },
        {
            "id": 3,
            "name": "TEST_menu2"
        }
    ]
}
```