### PR TITLE
新增 添加菜單動作 API

### DIFF
--- a/src/main/java/me/ian/workoutrecoder/controller/WorkoutMenuController.java
+++ b/src/main/java/me/ian/workoutrecoder/controller/WorkoutMenuController.java
@@ -2,9 +2,11 @@ package me.ian.workoutrecoder.controller;
 
 import jakarta.validation.Valid;
 import me.ian.workoutrecoder.controller.common.RestResponse;
+import me.ian.workoutrecoder.model.param.AddWorkoutMenuContentParam;
 import me.ian.workoutrecoder.model.param.CreateWorkoutMenuParam;
 import me.ian.workoutrecoder.model.param.EditWorkoutMenuParam;
 import me.ian.workoutrecoder.model.vo.GetWorkoutMenuListVO;
+import me.ian.workoutrecoder.service.WorkoutMenuFacade;
 import me.ian.workoutrecoder.service.WorkoutMenuService;
 import org.springframework.web.bind.annotation.*;
 
@@ -13,33 +15,40 @@ import java.util.List;
 @RestController
 @RequestMapping("/workout/menu")
 public class WorkoutMenuController {
-    private final WorkoutMenuService workoutMenuService;
+    private final WorkoutMenuFacade workoutMenuFacade;
 
-    public WorkoutMenuController(WorkoutMenuService workoutMenuService) {
-        this.workoutMenuService = workoutMenuService;
+    public WorkoutMenuController(WorkoutMenuFacade workoutMenuFacade) {
+        this.workoutMenuFacade = workoutMenuFacade;
     }
 
     @PostMapping
     public RestResponse<Integer> createMenu(@RequestHeader(name = "X-User-Id") Integer userId,
                                             @RequestBody @Valid CreateWorkoutMenuParam param) {
-        return new RestResponse<>(workoutMenuService.createWorkoutMenu(userId, param));
+        return new RestResponse<>(workoutMenuFacade.createWorkoutMenu(userId, param));
     }
 
     @GetMapping
     public RestResponse<List<GetWorkoutMenuListVO>> getMenuList(@RequestHeader(name = "X-User-Id") Integer userId) {
-        return new RestResponse<>(workoutMenuService.getWorkoutMenuList(userId));
+        return new RestResponse<>(workoutMenuFacade.getWorkoutMenuList(userId));
     }
 
     @PutMapping("/{menuId}")
     public RestResponse<Boolean> editWorkoutMenu(@RequestHeader(name = "X-User-Id") Integer userId,
                                                  @PathVariable("menuId") Integer menuId,
                                                  @RequestBody @Valid EditWorkoutMenuParam param) {
-        return new RestResponse<>(workoutMenuService.editWorkoutMenu(menuId, userId, param));
+        return new RestResponse<>(workoutMenuFacade.editWorkoutMenu(menuId, userId, param));
     }
 
     @DeleteMapping("/{menuId}")
     public RestResponse<Boolean> deleteWorkoutMenu(@RequestHeader(name = "X-User-Id") Integer userId,
                                                    @PathVariable("menuId") Integer menuId) {
-        return new RestResponse<>(workoutMenuService.deleteWorkoutMenu(userId, menuId));
+        return new RestResponse<>(workoutMenuFacade.deleteWorkoutMenu(userId, menuId));
+    }
+
+    @PostMapping("/{menuId}/action")
+    public RestResponse<Boolean> addWorkoutMenuContent(@RequestHeader(name = "X-User-Id") Integer userId,
+                                                       @PathVariable("menuId") Integer menuId,
+                                                       @RequestBody @Valid AddWorkoutMenuContentParam param) {
+        return new RestResponse<>(workoutMenuFacade.addMenuContent(userId, menuId, param));
     }
 }

--- a/src/main/java/me/ian/workoutrecoder/enums/WeekDayEnum.java
+++ b/src/main/java/me/ian/workoutrecoder/enums/WeekDayEnum.java
@@ -1,0 +1,18 @@
+package me.ian.workoutrecoder.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum WeekDayEnum {
+    MON("Monday"),
+    TUE("Tuesday"),
+    WED("Wednesday"),
+    THU("Thursday"),
+    FRI("Friday"),
+    SAT("Saturday"),
+    SUN("Sunday");
+
+    private String value;
+}

--- a/src/main/java/me/ian/workoutrecoder/exception/GlobalExceptionHandler.java
+++ b/src/main/java/me/ian/workoutrecoder/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import me.ian.workoutrecoder.controller.common.RestResponse;
 import me.ian.workoutrecoder.enums.ApplicationResponseCodeEnum;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.*;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -22,17 +23,17 @@ import javax.security.sasl.AuthenticationException;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler({
-            HttpMessageNotReadableException.class,
             MethodArgumentNotValidException.class,
             ConstraintViolationException.class
     })
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public RestResponse handleParamException(MethodArgumentNotValidException e) {
+    public RestResponse handleParamException(BindException e) {
         BindingResult bindingResult = e.getBindingResult();
         return new RestResponse(ApplicationResponseCodeEnum.PARAMETER_WRONG.getCode(), bindingResult.getAllErrors().get(0).getDefaultMessage());
     }
 
     @ExceptionHandler({
+            HttpMessageNotReadableException.class,
             MissingServletRequestParameterException.class,
             MissingRequestHeaderException.class
     })

--- a/src/main/java/me/ian/workoutrecoder/model/param/AddWorkoutMenuContentParam.java
+++ b/src/main/java/me/ian/workoutrecoder/model/param/AddWorkoutMenuContentParam.java
@@ -1,0 +1,17 @@
+package me.ian.workoutrecoder.model.param;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import me.ian.workoutrecoder.enums.WeekDayEnum;
+
+@Data
+public class AddWorkoutMenuContentParam {
+    @NotNull
+    private Integer actionId;
+    private WeekDayEnum day;
+    @Min(1)
+    private Integer set;
+    @Min(0)
+    private Double weight;
+}

--- a/src/main/java/me/ian/workoutrecoder/model/po/WorkoutMenuContentPO.java
+++ b/src/main/java/me/ian/workoutrecoder/model/po/WorkoutMenuContentPO.java
@@ -1,0 +1,33 @@
+package me.ian.workoutrecoder.model.po;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import me.ian.workoutrecoder.enums.WeekDayEnum;
+
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Table(name = "workout_menu_content")
+public class WorkoutMenuContentPO {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+    @ManyToOne(cascade = CascadeType.REFRESH, fetch = FetchType.LAZY)
+    @JoinColumn(name = "menu_id")
+    private WorkoutMenuPO menuId;
+    @ManyToOne(cascade = CascadeType.REFRESH, fetch = FetchType.LAZY)
+    @JoinColumn(name = "action_id")
+    private WorkoutActionPO actionId;
+    @Column(name = "`set`")
+    private Integer set;
+    @Column(name = "weight")
+    private Double weight;
+    @Column(name = "day")
+    @Enumerated(EnumType.STRING)
+    private WeekDayEnum day;
+    @Column(name = "create_at", insertable = false, updatable = false)
+    private LocalDateTime createAt;
+    @Column(name = "update_at", insertable = false, updatable = false)
+    private LocalDateTime updateAt;
+}

--- a/src/main/java/me/ian/workoutrecoder/repository/WorkoutMenuContentRepository.java
+++ b/src/main/java/me/ian/workoutrecoder/repository/WorkoutMenuContentRepository.java
@@ -1,0 +1,7 @@
+package me.ian.workoutrecoder.repository;
+
+import me.ian.workoutrecoder.model.po.WorkoutMenuContentPO;
+import org.springframework.data.repository.CrudRepository;
+
+public interface WorkoutMenuContentRepository extends CrudRepository<WorkoutMenuContentPO, Integer> {
+}

--- a/src/main/java/me/ian/workoutrecoder/service/WorkoutMenuContentService.java
+++ b/src/main/java/me/ian/workoutrecoder/service/WorkoutMenuContentService.java
@@ -1,0 +1,7 @@
+package me.ian.workoutrecoder.service;
+
+import me.ian.workoutrecoder.model.param.AddWorkoutMenuContentParam;
+
+public interface WorkoutMenuContentService {
+    boolean addMenuContent(Integer userId, Integer menuId, AddWorkoutMenuContentParam param);
+}

--- a/src/main/java/me/ian/workoutrecoder/service/WorkoutMenuFacade.java
+++ b/src/main/java/me/ian/workoutrecoder/service/WorkoutMenuFacade.java
@@ -1,0 +1,20 @@
+package me.ian.workoutrecoder.service;
+
+import me.ian.workoutrecoder.model.param.AddWorkoutMenuContentParam;
+import me.ian.workoutrecoder.model.param.CreateWorkoutMenuParam;
+import me.ian.workoutrecoder.model.param.EditWorkoutMenuParam;
+import me.ian.workoutrecoder.model.vo.GetWorkoutMenuListVO;
+
+import java.util.List;
+
+public interface WorkoutMenuFacade {
+    Integer createWorkoutMenu(Integer userId, CreateWorkoutMenuParam param);
+
+    List<GetWorkoutMenuListVO> getWorkoutMenuList(Integer userId);
+
+    boolean editWorkoutMenu(Integer menuId, Integer userId, EditWorkoutMenuParam param);
+
+    boolean deleteWorkoutMenu(Integer userId, Integer menuId);
+
+    boolean addMenuContent(Integer userId, Integer menuId, AddWorkoutMenuContentParam param);
+}

--- a/src/main/java/me/ian/workoutrecoder/service/impl/WorkoutMenuContentServiceImpl.java
+++ b/src/main/java/me/ian/workoutrecoder/service/impl/WorkoutMenuContentServiceImpl.java
@@ -68,13 +68,6 @@ public class WorkoutMenuContentServiceImpl implements WorkoutMenuContentService 
         return workoutActionPO.getUserId().equals(userId);
     }
 
-    private void checkMenuIsWeekly(Integer menuId) {
-        WorkoutMenuPO workoutMenuPO = workoutMenuRepository.findById(menuId).orElseThrow(() -> new RestException(ApplicationResponseCodeEnum.DATA_NOT_EXIST.getCode()));
-        if (!workoutMenuPO.getType().equals(MenuTypeEnum.WEEKLY.getCode())) {
-            throw new RestException(ApplicationResponseCodeEnum.PARAMETER_WRONG.getCode(), "Not weekly menu");
-        }
-    }
-
     private void checkMenuType(Integer menuId, Predicate<WorkoutMenuPO> predicate) {
         WorkoutMenuPO workoutMenuPO = workoutMenuRepository.findById(menuId).orElseThrow(() -> new RestException(ApplicationResponseCodeEnum.DATA_NOT_EXIST.getCode()));
         if (!predicate.test(workoutMenuPO)) {

--- a/src/main/java/me/ian/workoutrecoder/service/impl/WorkoutMenuContentServiceImpl.java
+++ b/src/main/java/me/ian/workoutrecoder/service/impl/WorkoutMenuContentServiceImpl.java
@@ -1,0 +1,56 @@
+package me.ian.workoutrecoder.service.impl;
+
+import me.ian.workoutrecoder.enums.ApplicationResponseCodeEnum;
+import me.ian.workoutrecoder.exception.RestException;
+import me.ian.workoutrecoder.model.param.AddWorkoutMenuContentParam;
+import me.ian.workoutrecoder.model.po.WorkoutActionPO;
+import me.ian.workoutrecoder.model.po.WorkoutMenuContentPO;
+import me.ian.workoutrecoder.model.po.WorkoutMenuPO;
+import me.ian.workoutrecoder.repository.WorkoutActionRepository;
+import me.ian.workoutrecoder.repository.WorkoutMenuContentRepository;
+import me.ian.workoutrecoder.service.WorkoutMenuContentService;
+import org.springframework.stereotype.Service;
+
+@Service
+public class WorkoutMenuContentServiceImpl implements WorkoutMenuContentService {
+    private final WorkoutMenuContentRepository workoutMenuContentRepository;
+    private final WorkoutActionRepository workoutActionRepository;
+
+    public WorkoutMenuContentServiceImpl(WorkoutMenuContentRepository workoutMenuContentRepository, WorkoutActionRepository workoutActionRepository) {
+        this.workoutMenuContentRepository = workoutMenuContentRepository;
+        this.workoutActionRepository = workoutActionRepository;
+    }
+
+    @Override
+    public boolean addMenuContent(Integer userId, Integer menuId, AddWorkoutMenuContentParam param) {
+        if (!isActionBelongUser(userId, param.getActionId())) {
+            throw new RestException(ApplicationResponseCodeEnum.PARAMETER_WRONG.getCode(), "Not your action");
+        }
+
+        WorkoutMenuPO workoutMenuPO = new WorkoutMenuPO();
+        workoutMenuPO.setId(menuId);
+
+        WorkoutActionPO workoutActionPO = new WorkoutActionPO();
+        workoutActionPO.setId(param.getActionId());
+
+        try {
+            WorkoutMenuContentPO workoutMenuContentPO = new WorkoutMenuContentPO();
+            workoutMenuContentPO.setMenuId(workoutMenuPO);
+            workoutMenuContentPO.setActionId(workoutActionPO);
+            workoutMenuContentPO.setSet(param.getSet());
+            workoutMenuContentPO.setWeight(param.getWeight());
+            workoutMenuContentPO.setDay(param.getDay());
+
+            workoutMenuContentRepository.save(workoutMenuContentPO);
+
+            return true;
+        } catch (Exception e) {
+            throw new RestException(ApplicationResponseCodeEnum.SYSTEM_ERROR.getCode());
+        }
+    }
+
+    private boolean isActionBelongUser(Integer userId, Integer actionId) {
+        WorkoutActionPO workoutActionPO = workoutActionRepository.findById(actionId).orElseThrow(() -> new RestException(ApplicationResponseCodeEnum.PARAMETER_WRONG.getCode()));
+        return workoutActionPO.getUserId().equals(userId);
+    }
+}

--- a/src/main/java/me/ian/workoutrecoder/service/impl/WorkoutMenuContentServiceImpl.java
+++ b/src/main/java/me/ian/workoutrecoder/service/impl/WorkoutMenuContentServiceImpl.java
@@ -13,6 +13,8 @@ import me.ian.workoutrecoder.repository.WorkoutMenuRepository;
 import me.ian.workoutrecoder.service.WorkoutMenuContentService;
 import org.springframework.stereotype.Service;
 
+import java.util.function.Predicate;
+
 @Service
 public class WorkoutMenuContentServiceImpl implements WorkoutMenuContentService {
     private final WorkoutMenuContentRepository workoutMenuContentRepository;
@@ -34,7 +36,9 @@ public class WorkoutMenuContentServiceImpl implements WorkoutMenuContentService 
         }
 
         if (param.getDay() != null) {
-            this.checkoutMenuIsWeekly(menuId);
+            this.checkMenuType(menuId, po -> po.getType().equals(MenuTypeEnum.WEEKLY.getCode()));
+        } else {
+            this.checkMenuType(menuId, po -> po.getType().equals(MenuTypeEnum.CUSTOM.getCode()));
         }
 
         WorkoutMenuPO workoutMenuPO = new WorkoutMenuPO();
@@ -64,10 +68,17 @@ public class WorkoutMenuContentServiceImpl implements WorkoutMenuContentService 
         return workoutActionPO.getUserId().equals(userId);
     }
 
-    private void checkoutMenuIsWeekly(Integer menuId) {
+    private void checkMenuIsWeekly(Integer menuId) {
         WorkoutMenuPO workoutMenuPO = workoutMenuRepository.findById(menuId).orElseThrow(() -> new RestException(ApplicationResponseCodeEnum.DATA_NOT_EXIST.getCode()));
         if (!workoutMenuPO.getType().equals(MenuTypeEnum.WEEKLY.getCode())) {
             throw new RestException(ApplicationResponseCodeEnum.PARAMETER_WRONG.getCode(), "Not weekly menu");
+        }
+    }
+
+    private void checkMenuType(Integer menuId, Predicate<WorkoutMenuPO> predicate) {
+        WorkoutMenuPO workoutMenuPO = workoutMenuRepository.findById(menuId).orElseThrow(() -> new RestException(ApplicationResponseCodeEnum.DATA_NOT_EXIST.getCode()));
+        if (!predicate.test(workoutMenuPO)) {
+            throw new RestException(ApplicationResponseCodeEnum.PARAMETER_WRONG.getCode(), "Menu type wrong");
         }
     }
 }

--- a/src/main/java/me/ian/workoutrecoder/service/impl/WorkoutMenuContentServiceImpl.java
+++ b/src/main/java/me/ian/workoutrecoder/service/impl/WorkoutMenuContentServiceImpl.java
@@ -1,6 +1,7 @@
 package me.ian.workoutrecoder.service.impl;
 
 import me.ian.workoutrecoder.enums.ApplicationResponseCodeEnum;
+import me.ian.workoutrecoder.enums.MenuTypeEnum;
 import me.ian.workoutrecoder.exception.RestException;
 import me.ian.workoutrecoder.model.param.AddWorkoutMenuContentParam;
 import me.ian.workoutrecoder.model.po.WorkoutActionPO;
@@ -8,6 +9,7 @@ import me.ian.workoutrecoder.model.po.WorkoutMenuContentPO;
 import me.ian.workoutrecoder.model.po.WorkoutMenuPO;
 import me.ian.workoutrecoder.repository.WorkoutActionRepository;
 import me.ian.workoutrecoder.repository.WorkoutMenuContentRepository;
+import me.ian.workoutrecoder.repository.WorkoutMenuRepository;
 import me.ian.workoutrecoder.service.WorkoutMenuContentService;
 import org.springframework.stereotype.Service;
 
@@ -15,16 +17,24 @@ import org.springframework.stereotype.Service;
 public class WorkoutMenuContentServiceImpl implements WorkoutMenuContentService {
     private final WorkoutMenuContentRepository workoutMenuContentRepository;
     private final WorkoutActionRepository workoutActionRepository;
+    private final WorkoutMenuRepository workoutMenuRepository;
 
-    public WorkoutMenuContentServiceImpl(WorkoutMenuContentRepository workoutMenuContentRepository, WorkoutActionRepository workoutActionRepository) {
+    public WorkoutMenuContentServiceImpl(WorkoutMenuContentRepository workoutMenuContentRepository,
+                                         WorkoutActionRepository workoutActionRepository,
+                                         WorkoutMenuRepository workoutMenuRepository) {
         this.workoutMenuContentRepository = workoutMenuContentRepository;
         this.workoutActionRepository = workoutActionRepository;
+        this.workoutMenuRepository = workoutMenuRepository;
     }
 
     @Override
     public boolean addMenuContent(Integer userId, Integer menuId, AddWorkoutMenuContentParam param) {
         if (!isActionBelongUser(userId, param.getActionId())) {
             throw new RestException(ApplicationResponseCodeEnum.PARAMETER_WRONG.getCode(), "Not your action");
+        }
+
+        if (param.getDay() != null) {
+            this.checkoutMenuIsWeekly(menuId);
         }
 
         WorkoutMenuPO workoutMenuPO = new WorkoutMenuPO();
@@ -52,5 +62,12 @@ public class WorkoutMenuContentServiceImpl implements WorkoutMenuContentService 
     private boolean isActionBelongUser(Integer userId, Integer actionId) {
         WorkoutActionPO workoutActionPO = workoutActionRepository.findById(actionId).orElseThrow(() -> new RestException(ApplicationResponseCodeEnum.PARAMETER_WRONG.getCode()));
         return workoutActionPO.getUserId().equals(userId);
+    }
+
+    private void checkoutMenuIsWeekly(Integer menuId) {
+        WorkoutMenuPO workoutMenuPO = workoutMenuRepository.findById(menuId).orElseThrow(() -> new RestException(ApplicationResponseCodeEnum.DATA_NOT_EXIST.getCode()));
+        if (!workoutMenuPO.getType().equals(MenuTypeEnum.WEEKLY.getCode())) {
+            throw new RestException(ApplicationResponseCodeEnum.PARAMETER_WRONG.getCode(), "Not weekly menu");
+        }
     }
 }

--- a/src/main/java/me/ian/workoutrecoder/service/impl/WorkoutMenuFacadeImpl.java
+++ b/src/main/java/me/ian/workoutrecoder/service/impl/WorkoutMenuFacadeImpl.java
@@ -1,0 +1,48 @@
+package me.ian.workoutrecoder.service.impl;
+
+import me.ian.workoutrecoder.model.param.AddWorkoutMenuContentParam;
+import me.ian.workoutrecoder.model.param.CreateWorkoutMenuParam;
+import me.ian.workoutrecoder.model.param.EditWorkoutMenuParam;
+import me.ian.workoutrecoder.model.vo.GetWorkoutMenuListVO;
+import me.ian.workoutrecoder.service.WorkoutMenuContentService;
+import me.ian.workoutrecoder.service.WorkoutMenuFacade;
+import me.ian.workoutrecoder.service.WorkoutMenuService;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class WorkoutMenuFacadeImpl implements WorkoutMenuFacade {
+    private final WorkoutMenuService workoutMenuService;
+    private final WorkoutMenuContentService workoutMenuContentService;
+
+    public WorkoutMenuFacadeImpl(WorkoutMenuService workoutMenuService, WorkoutMenuContentService workoutMenuContentService) {
+        this.workoutMenuService = workoutMenuService;
+        this.workoutMenuContentService = workoutMenuContentService;
+    }
+
+    @Override
+    public Integer createWorkoutMenu(Integer userId, CreateWorkoutMenuParam param) {
+        return workoutMenuService.createWorkoutMenu(userId, param);
+    }
+
+    @Override
+    public List<GetWorkoutMenuListVO> getWorkoutMenuList(Integer userId) {
+        return workoutMenuService.getWorkoutMenuList(userId);
+    }
+
+    @Override
+    public boolean editWorkoutMenu(Integer menuId, Integer userId, EditWorkoutMenuParam param) {
+        return workoutMenuService.editWorkoutMenu(menuId, userId, param);
+    }
+
+    @Override
+    public boolean deleteWorkoutMenu(Integer userId, Integer menuId) {
+        return workoutMenuService.deleteWorkoutMenu(userId, menuId);
+    }
+
+    @Override
+    public boolean addMenuContent(Integer userId, Integer menuId, AddWorkoutMenuContentParam param) {
+        return workoutMenuContentService.addMenuContent(userId, menuId, param);
+    }
+}


### PR DESCRIPTION
# Modification
* 調整 `HttpMessageNotReadableException.class` 的處理位置
* 新增星期 enum
* 新增添加動作到菜單的相關實作
* 新增對應 workout_menu_content 表的相關 PO 跟 repository
* 將菜單相關操作跟添加菜單相關方法透過 facade 模式封裝後, 讓 controller 透過 facade 介面使用相關功能

# Implementation Logic
1. 先讓框架判斷傳入的參數是否為空或是是否可以合法轉換成 enum
2. 判斷傳入的 action 是否屬於該使用者, 不是則拋出例外
3. 判斷如果參數的 day 不是空值, 則判斷菜單是不是整週菜單, 反之則判斷是否為自訂菜單
4. 建立 po, 寫入 DB

# Local Test
目前 workout_menu 資料
```sql
mysql> SELECT * FROM workout_logger.workout_menu WHERE user_id = 2;
+----+---------+------------+------+---------------------+---------------------+
| id | user_id | name       | type | create_at           | update_at           |
+----+---------+------------+------+---------------------+---------------------+
|  1 |       2 | TEST_edit  |    1 | 2024-07-14 16:45:22 | 2024-07-19 00:20:39 |
|  3 |       2 | TEST_menu2 |    2 | 2024-07-14 16:49:41 | 2024-07-19 00:22:18 |
+----+---------+------------+------+---------------------+---------------------+
2 rows in set (0.01 sec)
```

查看 workout_action 資料
```sql
mysql> SELECT * FROM workout_logger.workout_action;
+----+---------+-------+--------------+-------------+---------------------+---------------------+
| id | user_id | parts | name         | description | create_at           | update_at           |
+----+---------+-------+--------------+-------------+---------------------+---------------------+
|  1 |       1 | 肩    | 啞鈴肩推     |             | 2024-07-02 17:42:34 | 2024-07-02 17:42:34 |
|  4 |       2 | 肩    | 啞鈴肩推     |             | 2024-07-02 17:42:34 | 2024-07-02 17:42:34 |
|  5 |       2 | 胸    | 啞鈴胸推     | NULL        | 2024-07-17 06:48:26 | 2024-07-17 06:48:26 |
|  6 |       2 | 腿    | 深蹲         | NULL        | 2024-07-17 06:49:05 | 2024-07-17 06:49:05 |
+----+---------+-------+--------------+-------------+---------------------+---------------------+
4 rows in set (0.00 sec)
```

## case1: 添加動作到不存在的菜單
**預期回傳**  
code: 11000

```sh
curl --location 'http://localhost:8080/workout/menu/4/action' \
--header 'X-User-Id: 2' \
--header 'Content-Type: application/json' \
--data '{
	"actionId": 4,
	"day": null,
	"set": 1,
	"weight": 30
}'
```
Response
```json
{
    "code": 11000,
    "msg": "Data not exist",
    "data": null
}
```

## case2 添加動作到整週菜單且 day 為 null
**預期回傳**  
code: 10001

```sh
curl --location 'http://localhost:8080/workout/menu/3/action' \
--header 'X-User-Id: 2' \
--header 'Content-Type: application/json' \
--data '{
	"actionId": 4,
	"day": null,
	"set": 1,
	"weight": 30
}'
```
Response
```json
{
    "code": 10001,
    "msg": "Menu type wrong",
    "data": null
}
```

## case3: 添加動作到自訂菜單且 day 不為 null
**預期回傳**  
code: 10001

```sh
curl --location 'http://localhost:8080/workout/menu/1/action' \
--header 'X-User-Id: 2' \
--header 'Content-Type: application/json' \
--data '{
	"actionId": 4,
	"day": "MON",
	"set": 1,
	"weight": 30
}'
```
Response
```json
{
    "code": 10001,
    "msg": "Menu type wrong",
    "data": null
}
```

## case4: 添加動作到自訂菜單且 day 為 null
**預期回傳**  
code: 1

```sh
curl --location 'http://localhost:8080/workout/menu/1/action' \
--header 'X-User-Id: 2' \
--header 'Content-Type: application/json' \
--data '{
	"actionId": 4,
	"day": null,
	"set": 1,
	"weight": 30
}'
```
Response
```json
{
    "code": 1,
    "msg": null,
    "data": true
}
```

## case5: 添加不屬於該 user 的動作
**預期回傳**  
code: 10001
```sh
curl --location 'http://localhost:8080/workout/menu/1/action' \
--header 'X-User-Id: 2' \
--header 'Content-Type: application/json' \
--data '{
	"actionId": 1,
	"day": null,
	"set": 1,
	"weight": 30
}'
```
Response
```json
{
    "code": 10001,
    "msg": "Not your action",
    "data": null
}
```