### PR TITLE
新增 刪除菜單動作 API

### DIFF
--- a/src/main/java/me/ian/workoutrecoder/controller/WorkoutMenuController.java
+++ b/src/main/java/me/ian/workoutrecoder/controller/WorkoutMenuController.java
@@ -2,12 +2,12 @@ package me.ian.workoutrecoder.controller;
 
 import jakarta.validation.Valid;
 import me.ian.workoutrecoder.controller.common.RestResponse;
+import me.ian.workoutrecoder.enums.WeekDayEnum;
 import me.ian.workoutrecoder.model.param.AddWorkoutMenuContentParam;
 import me.ian.workoutrecoder.model.param.CreateWorkoutMenuParam;
 import me.ian.workoutrecoder.model.param.EditWorkoutMenuParam;
 import me.ian.workoutrecoder.model.vo.GetWorkoutMenuListVO;
 import me.ian.workoutrecoder.service.WorkoutMenuFacade;
-import me.ian.workoutrecoder.service.WorkoutMenuService;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -50,5 +50,13 @@ public class WorkoutMenuController {
                                                        @PathVariable("menuId") Integer menuId,
                                                        @RequestBody @Valid AddWorkoutMenuContentParam param) {
         return new RestResponse<>(workoutMenuFacade.addMenuContent(userId, menuId, param));
+    }
+
+    @DeleteMapping("/{menuId}/action/{actionId}")
+    public RestResponse<Boolean> deleteWorkoutMenuContent(@RequestHeader(name = "X-User-Id") Integer userId,
+                                                          @PathVariable("menuId") Integer menuId,
+                                                          @PathVariable("actionId") Integer actionId,
+                                                          @RequestParam(value = "day", required = false)WeekDayEnum day) {
+        return new RestResponse<>(workoutMenuFacade.deleteMenuContent(menuId, actionId, day));
     }
 }

--- a/src/main/java/me/ian/workoutrecoder/repository/WorkoutMenuContentRepository.java
+++ b/src/main/java/me/ian/workoutrecoder/repository/WorkoutMenuContentRepository.java
@@ -1,7 +1,29 @@
 package me.ian.workoutrecoder.repository;
 
+import me.ian.workoutrecoder.enums.WeekDayEnum;
 import me.ian.workoutrecoder.model.po.WorkoutMenuContentPO;
+import me.ian.workoutrecoder.repository.specs.WorkoutMenuContentSpecs;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.repository.CrudRepository;
 
-public interface WorkoutMenuContentRepository extends CrudRepository<WorkoutMenuContentPO, Integer> {
+public interface WorkoutMenuContentRepository extends CrudRepository<WorkoutMenuContentPO, Integer>, JpaSpecificationExecutor<WorkoutMenuContentPO> {
+
+    default long deleteBySpecification(Integer menuId, Integer actionId, WeekDayEnum day) {
+        Specification<WorkoutMenuContentPO> specification = Specification.where(null);
+
+        if (menuId != null) {
+            specification = specification.and(WorkoutMenuContentSpecs.menuIdEquals(menuId));
+        }
+
+        if (actionId != null) {
+            specification = specification.and(WorkoutMenuContentSpecs.actionIdEquals(actionId));
+        }
+
+        if (day != null) {
+            specification = specification.and(WorkoutMenuContentSpecs.dayEquals(day));
+        }
+
+        return delete(specification);
+    }
 }

--- a/src/main/java/me/ian/workoutrecoder/repository/specs/WorkoutMenuContentSpecs.java
+++ b/src/main/java/me/ian/workoutrecoder/repository/specs/WorkoutMenuContentSpecs.java
@@ -1,0 +1,20 @@
+package me.ian.workoutrecoder.repository.specs;
+
+import me.ian.workoutrecoder.enums.WeekDayEnum;
+import me.ian.workoutrecoder.model.po.WorkoutMenuContentPO;
+import org.springframework.data.jpa.domain.Specification;
+
+public class WorkoutMenuContentSpecs {
+
+    public static Specification<WorkoutMenuContentPO> menuIdEquals(Integer menuId) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("menuId").get("id"), menuId);
+    }
+
+    public static Specification<WorkoutMenuContentPO> actionIdEquals(Integer actionId) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("actionId").get("id"), actionId);
+    }
+
+    public static Specification<WorkoutMenuContentPO> dayEquals(WeekDayEnum day) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("day"), day);
+    }
+}

--- a/src/main/java/me/ian/workoutrecoder/service/WorkoutMenuContentService.java
+++ b/src/main/java/me/ian/workoutrecoder/service/WorkoutMenuContentService.java
@@ -1,7 +1,10 @@
 package me.ian.workoutrecoder.service;
 
+import me.ian.workoutrecoder.enums.WeekDayEnum;
 import me.ian.workoutrecoder.model.param.AddWorkoutMenuContentParam;
 
 public interface WorkoutMenuContentService {
     boolean addMenuContent(Integer userId, Integer menuId, AddWorkoutMenuContentParam param);
+
+    boolean deleteMenuContent(Integer menuId, Integer actionId, WeekDayEnum day);
 }

--- a/src/main/java/me/ian/workoutrecoder/service/WorkoutMenuFacade.java
+++ b/src/main/java/me/ian/workoutrecoder/service/WorkoutMenuFacade.java
@@ -1,5 +1,6 @@
 package me.ian.workoutrecoder.service;
 
+import me.ian.workoutrecoder.enums.WeekDayEnum;
 import me.ian.workoutrecoder.model.param.AddWorkoutMenuContentParam;
 import me.ian.workoutrecoder.model.param.CreateWorkoutMenuParam;
 import me.ian.workoutrecoder.model.param.EditWorkoutMenuParam;
@@ -17,4 +18,6 @@ public interface WorkoutMenuFacade {
     boolean deleteWorkoutMenu(Integer userId, Integer menuId);
 
     boolean addMenuContent(Integer userId, Integer menuId, AddWorkoutMenuContentParam param);
+
+    boolean deleteMenuContent(Integer menuId, Integer actionId, WeekDayEnum day);
 }

--- a/src/main/java/me/ian/workoutrecoder/service/impl/WorkoutMenuContentServiceImpl.java
+++ b/src/main/java/me/ian/workoutrecoder/service/impl/WorkoutMenuContentServiceImpl.java
@@ -2,6 +2,7 @@ package me.ian.workoutrecoder.service.impl;
 
 import me.ian.workoutrecoder.enums.ApplicationResponseCodeEnum;
 import me.ian.workoutrecoder.enums.MenuTypeEnum;
+import me.ian.workoutrecoder.enums.WeekDayEnum;
 import me.ian.workoutrecoder.exception.RestException;
 import me.ian.workoutrecoder.model.param.AddWorkoutMenuContentParam;
 import me.ian.workoutrecoder.model.po.WorkoutActionPO;
@@ -12,6 +13,7 @@ import me.ian.workoutrecoder.repository.WorkoutMenuContentRepository;
 import me.ian.workoutrecoder.repository.WorkoutMenuRepository;
 import me.ian.workoutrecoder.service.WorkoutMenuContentService;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.function.Predicate;
 
@@ -73,5 +75,17 @@ public class WorkoutMenuContentServiceImpl implements WorkoutMenuContentService 
         if (!predicate.test(workoutMenuPO)) {
             throw new RestException(ApplicationResponseCodeEnum.PARAMETER_WRONG.getCode(), "Menu type wrong");
         }
+    }
+
+    @Override
+    @Transactional
+    public boolean deleteMenuContent(Integer menuId, Integer actionId, WeekDayEnum day) {
+        if (day != null) {
+            this.checkMenuType(menuId, po -> po.getType().equals(MenuTypeEnum.WEEKLY.getCode()));
+        } else {
+            this.checkMenuType(menuId, po -> po.getType().equals(MenuTypeEnum.CUSTOM.getCode()));
+        }
+
+        return workoutMenuContentRepository.deleteBySpecification(menuId, actionId, day) > 0;
     }
 }

--- a/src/main/java/me/ian/workoutrecoder/service/impl/WorkoutMenuFacadeImpl.java
+++ b/src/main/java/me/ian/workoutrecoder/service/impl/WorkoutMenuFacadeImpl.java
@@ -1,5 +1,6 @@
 package me.ian.workoutrecoder.service.impl;
 
+import me.ian.workoutrecoder.enums.WeekDayEnum;
 import me.ian.workoutrecoder.model.param.AddWorkoutMenuContentParam;
 import me.ian.workoutrecoder.model.param.CreateWorkoutMenuParam;
 import me.ian.workoutrecoder.model.param.EditWorkoutMenuParam;
@@ -44,5 +45,10 @@ public class WorkoutMenuFacadeImpl implements WorkoutMenuFacade {
     @Override
     public boolean addMenuContent(Integer userId, Integer menuId, AddWorkoutMenuContentParam param) {
         return workoutMenuContentService.addMenuContent(userId, menuId, param);
+    }
+
+    @Override
+    public boolean deleteMenuContent(Integer menuId, Integer actionId, WeekDayEnum day) {
+        return workoutMenuContentService.deleteMenuContent(menuId, actionId, day);
     }
 }


### PR DESCRIPTION
# Modification
新增 刪除菜單動作 API  
刪除前會判斷傳入的參數是否符合對應的菜單

# Local Test
目前資料庫資料
```sql
mysql> SELECT * FROM workout_menu_content;
+----+---------+-----------+-----+--------+------+---------------------+---------------------+
| id | menu_id | action_id | set | weight | day  | create_at           | update_at           |
+----+---------+-----------+-----+--------+------+---------------------+---------------------+
|  1 |       1 |         4 |   1 |  30.00 | NULL | 2024-07-21 16:17:08 | 2024-07-21 16:17:08 |
|  3 |       3 |         6 |   1 |  30.00 | SUN  | 2024-07-24 07:10:31 | 2024-07-24 07:32:33 |
|  9 |       3 |         4 |   1 |  30.00 | SUN  | 2024-07-24 07:10:31 | 2024-07-24 07:32:30 |
| 11 |       3 |         5 |   1 |  30.00 | MON  | 2024-07-24 07:10:31 | 2024-07-24 07:32:30 |
| 12 |       1 |         5 |   1 |  30.00 | NULL | 2024-07-21 16:17:08 | 2024-07-21 16:17:08 |
+----+---------+-----------+-----+--------+------+---------------------+---------------------+
5 rows in set (0.00 sec)
```

菜單資料
```sql
mysql> SELECT * FROM workout_menu;
+----+---------+------------+------+---------------------+---------------------+
| id | user_id | name       | type | create_at           | update_at           |
+----+---------+------------+------+---------------------+---------------------+
|  1 |       2 | TEST_edit  |    1 | 2024-07-14 16:45:22 | 2024-07-19 00:20:39 |
|  3 |       2 | TEST_menu2 |    2 | 2024-07-14 16:49:41 | 2024-07-19 00:22:18 |
+----+---------+------------+------+---------------------+---------------------+
2 rows in set (0.00 sec)
```

## case1: 刪除自訂菜單內容
```sh
curl --location --request DELETE 'http://localhost:8080/workout/menu/1/action/5' \
--header 'X-User-Id: 1'
```
Response
```json
{
    "code": 1,
    "msg": null,
    "data": true
}
```
查看資料庫
```sql
mysql> SELECT * FROM workout_menu_content;
+----+---------+-----------+-----+--------+------+---------------------+---------------------+
| id | menu_id | action_id | set | weight | day  | create_at           | update_at           |
+----+---------+-----------+-----+--------+------+---------------------+---------------------+
|  1 |       1 |         4 |   1 |  30.00 | NULL | 2024-07-21 16:17:08 | 2024-07-21 16:17:08 |
|  3 |       3 |         6 |   1 |  30.00 | SUN  | 2024-07-24 07:10:31 | 2024-07-24 07:32:33 |
|  9 |       3 |         4 |   1 |  30.00 | SUN  | 2024-07-24 07:10:31 | 2024-07-24 07:32:30 |
| 11 |       3 |         5 |   1 |  30.00 | MON  | 2024-07-24 07:10:31 | 2024-07-24 07:32:30 |
+----+---------+-----------+-----+--------+------+---------------------+---------------------+
4 rows in set (0.00 sec)
```

## case2: 刪除整週菜單動作, 但未指定哪天
```sh
curl --location --request DELETE 'http://localhost:8080/workout/menu/3/action/5' \
--header 'X-User-Id: 1'
```
Response
```json
{
    "code": 10001,
    "msg": "Menu type wrong",
    "data": null
}
```

## case3: 刪除整週菜單動作, 且有指定哪天
```sh
curl --location --request DELETE 'http://localhost:8080/workout/menu/3/action/5?day=MON' \
--header 'X-User-Id: 1'
```
Response
```json
{
    "code": 1,
    "msg": null,
    "data": true
}
```

查看資料庫
```sql
mysql> SELECT * FROM workout_menu_content;
+----+---------+-----------+-----+--------+------+---------------------+---------------------+
| id | menu_id | action_id | set | weight | day  | create_at           | update_at           |
+----+---------+-----------+-----+--------+------+---------------------+---------------------+
|  1 |       1 |         4 |   1 |  30.00 | NULL | 2024-07-21 16:17:08 | 2024-07-21 16:17:08 |
|  3 |       3 |         6 |   1 |  30.00 | SUN  | 2024-07-24 07:10:31 | 2024-07-24 07:32:33 |
|  9 |       3 |         4 |   1 |  30.00 | SUN  | 2024-07-24 07:10:31 | 2024-07-24 07:32:30 |
+----+---------+-----------+-----+--------+------+---------------------+---------------------+
3 rows in set (0.00 sec)
```